### PR TITLE
Fix issue when tag description contains a slash

### DIFF
--- a/src/Tags/Formatter/AlignBetterFormatter.php
+++ b/src/Tags/Formatter/AlignBetterFormatter.php
@@ -65,7 +65,7 @@ class AlignBetterFormatter implements Formatter
         $description = '';
         if ($tag instanceof BaseTag && $tag->getDescription()) {
             $description = (string) $tag->getDescription();
-            $tagString   = preg_replace('/\s*' . preg_quote($description) . '$/', '', $tagString);
+            $tagString   = preg_replace('/\s*' . preg_quote($description, '/') . '$/', '', $tagString);
         }
 
         $parts = explode(' ', $tagString);

--- a/tests/Tags/Formatter/AlignBetterFormatterTest.php
+++ b/tests/Tags/Formatter/AlignBetterFormatterTest.php
@@ -150,6 +150,7 @@ class AlignBetterFormatterTest extends TestCase
         $r['Method - Static']          = [['static', 'array', 'methodName()', 'Custom Description'], new Method('methodName', [], $this->type, true, $this->description)];
         $r['Method - Not Static']      = [['', 'array', 'methodName()', 'Custom Description'], new Method('methodName', [], $this->type, false, $this->description)];
         $r['Method - With Parameters'] = [['', 'array', 'methodName(array $paramName, array $paramName2)', 'Custom Description'], new Method('methodName', $this->argumentsMultiple, $this->type, false, $this->description)];
+        $r['With Slashes']             = [['', '', '', 'Something with / slashes'], new Generic('generic', new Description('Something with / slashes'))];
         return $r;
     }
 


### PR DESCRIPTION
We were getting the following error when processing a tag with a description containing a forward slash:

```
TypeError : explode() expects parameter 2 to be string, null given
```

This was because `preg_replace` was returning `null` due to thinking that the pattern had a bunch of modifiers after that second slash.